### PR TITLE
Fix tests & compile for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ inThisBuild(
     pgpSecretRing := file("/tmp/secret.asc"),
     scmInfo := Some(
       ScmInfo(url("https://github.com/zio/zio.zmx/"), "scm:git:git@github.com:zio/zio.zmx.git")
-    )
+    ),
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )
 )
 
@@ -39,7 +40,6 @@ val fansiVersion     = "0.2.14"
 val laminarVersion   = "0.13.0"
 val laminextVersion  = "0.13.6"
 
-testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 

--- a/core/jvm/src/main/scala/zio/zmx/diagnostics/nio/SocketChannel.scala
+++ b/core/jvm/src/main/scala/zio/zmx/diagnostics/nio/SocketChannel.scala
@@ -22,7 +22,6 @@ import java.nio.channels.{
   SocketChannel => JSocketChannel,
   SelectableChannel => JSelectableChannel
 }
-import java.nio.{ ByteBuffer => JByteBuffer }
 
 import zio.{ IO, UIO }
 

--- a/core/jvm/src/main/scala/zio/zmx/metrics/MetricAspect.scala
+++ b/core/jvm/src/main/scala/zio/zmx/metrics/MetricAspect.scala
@@ -132,7 +132,7 @@ object MetricAspect {
     f: Duration => Double
   ): MetricAspect[A] =
     new MetricAspect[A] {
-      val key                                                     = MetricKey.Histogram(name, boundaries, tags: _*)
+      val key                                                     = MetricKey.Histogram(name, boundaries, Chunk.fromIterable(tags))
       val histogram                                               = metricState.getHistogram(key)
       def apply[R, E, A1 <: A](zio: ZIO[R, E, A1]): ZIO[R, E, A1] =
         zio.timedWith(ZIO.succeed(System.nanoTime)).flatMap { case (duration, a) =>


### PR DESCRIPTION
This fixes the compile for Scala 2.13 and makes the tests run again 