### PR TITLE
Restricting Scala Version for JS client to 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val client =
       run / javaOptions += "-Djava.net.preferIPv4Stack=true"
     )
     .jsSettings(
+      crossScalaVersions := Seq(Scala213),
       libraryDependencies ++= Seq(
         "com.raquo"            %%% "laminar"         % laminarVersion,
         "io.github.kitlangton" %%% "animus"          % animusVersion,

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -4,9 +4,9 @@ import sbtbuildinfo._
 import BuildInfoKeys._
 
 object BuildHelper {
-  private val Scala211 = "2.11.12"
-  private val Scala212 = "2.12.14"
-  private val Scala213 = "2.13.6"
+  val Scala211 = "2.11.12"
+  val Scala212 = "2.12.14"
+  val Scala213 = "2.13.6"
 
   private val stdOptions = Seq(
     "-encoding",


### PR DESCRIPTION
Restrict Scala Version for JS client to 2.13 due to Laminar required dependencies. 